### PR TITLE
Use latest management center version for integration tests

### DIFF
--- a/.github/terraform/terraform.tfvars
+++ b/.github/terraform/terraform.tfvars
@@ -12,7 +12,7 @@ gcp_instance_type = "f1-micro"
 gcp_label_key = "integration-test"
 gcp_label_value = "terraform"
 
-hazelcast_mancenter_version = "4.2020.08"
+hazelcast_mancenter_version = SET_MANAGEMENT_CENTER_VERSION
 
 gcp_ssh_user = "ubuntu"
 

--- a/.github/workflows/terraform-integration-tests.yml
+++ b/.github/workflows/terraform-integration-tests.yml
@@ -49,6 +49,23 @@ jobs:
           echo "Hazelcast GCP jar is: " target/hazelcast-gcp-*-SNAPSHOT.jar
           cp target/hazelcast-gcp-*-SNAPSHOT.jar ~/lib/hazelcast-gcp.jar
 
+      # FIND LATEST MANAGEMENT CENTER VERSION
+      - uses: actions/checkout@v2.3.4
+        with:
+          path: management-center-docker
+          repository: hazelcast/management-center-docker 
+          fetch-depth: 0
+
+      - name: Find latest management center version
+        run: |
+          cd management-center-docker
+          FILTERED_TAGS=$(git tag --list "v*" |  grep -E -v '.*(BETA|-).*' )
+          LATEST_TAG=$((IFS=$'\n' && echo "${FILTERED_TAGS[*]}") | sort | tail -n 1)
+          echo $LATEST_TAG
+
+          sed -i -e "s/SET_MANAGEMENT_CENTER_VERSION/\"${LATEST_TAG:1}\"/g" ../hazelcast-gcp/.github/terraform/terraform.tfvars
+
+
       # DOWNLOAD HAZELCAST JAR WITH VERSION DEFINED IN POM.XML
       - name: Download latest Hazelcast version
         run: |

--- a/.github/workflows/terraform-integration-tests.yml
+++ b/.github/workflows/terraform-integration-tests.yml
@@ -50,6 +50,7 @@ jobs:
           cp target/hazelcast-gcp-*-SNAPSHOT.jar ~/lib/hazelcast-gcp.jar
 
       # FIND LATEST MANAGEMENT CENTER VERSION
+      # We are not using the hazelcast/management-center repository because it is private.
       - uses: actions/checkout@v2.3.4
         with:
           path: management-center-docker
@@ -64,7 +65,6 @@ jobs:
           echo $LATEST_TAG
 
           sed -i -e "s/SET_MANAGEMENT_CENTER_VERSION/\"${LATEST_TAG:1}\"/g" ../hazelcast-gcp/.github/terraform/terraform.tfvars
-
 
       # DOWNLOAD HAZELCAST JAR WITH VERSION DEFINED IN POM.XML
       - name: Download latest Hazelcast version


### PR DESCRIPTION
Currently, integration tests use a static management center version ` 4.2020.08`. With this PR workflow gets the latest management center version from the [management-center-docker](https://github.com/hazelcast/management-center-docker) repository.